### PR TITLE
Fix wiki links

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ COMING SOON!
 
 #### Conventional usage method
 
- [Create Your First Project](Guides.Your-First-Project)
+ [Create Your First Project](https://github.com/ComplesaCwiminal/BedrockAPI/wiki/Guides.Your-First-Project)
 
 -----
 
 ### Overviews
 
-- [Module Overview](Modules.Module-Overview)
+- [Module Overview](https://github.com/ComplesaCwiminal/BedrockAPI/wiki/Modules.Module-Overview)
 
 ### Modules  
 


### PR DESCRIPTION
They were previously pointing to files in the repo that didn't exist because they were on the wiki, not the repo itself. This PR fixes that.